### PR TITLE
Fixed the path for the staticfile files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -54,7 +54,7 @@ mkdir -p openresty/nginx/cache/tmp
 
 if [[ -f Staticfile.auth ]]; then
   status "Enabling basic authentication"
-  mv Staticfile.auth nginx/conf/.htpasswd
+  mv Staticfile.auth openresty/nginx/conf/.htpasswd
   cat openresty/nginx/conf/.htpasswd | indent
   echo
   protip "Learn about basic authentication" "https://github.com/drnic/staticfile-buildpack#basic-authentication"

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -40,10 +40,10 @@ http {
     location / {
       root <%= ENV["APP_ROOT"] %>/public;
       index index.html index.htm Default.htm;
-      <% if File.exists?(File.join(ENV["APP_ROOT"], "nginx/conf/.enable_directory_index")) %>
+      <% if File.exists?(File.join(ENV["APP_ROOT"], "openresty/nginx/conf/.enable_directory_index")) %>
       autoindex on;
       <% end %>
-      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "nginx/conf/.htpasswd")) %>
+      <% if File.exists?(auth_file = File.join(ENV["APP_ROOT"], "openresty/nginx/conf/.htpasswd")) %>
       auth_basic "Restricted";                                #For Basic Auth
       auth_basic_user_file <%= auth_file %>;  #For Basic Auth
       <% end %>


### PR DESCRIPTION
Added the openresty folder to the path in the compile script where it moves the Staticfiles.auth to the nginx config folder.
Added the openresty folder to the path in the nginx.conf file where it looks for the .enable_directory_index and .htpasswd files.